### PR TITLE
add basic manual hwaccel support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,20 @@
-FROM node:18
+# use base image with ffmpeg and hwaccel support
+ARG base_image=ghcr.io/ersatztv/ersatztv-ffmpeg
+ARG base_image_tag=7.1.1
 
-# Install FFmpeg and Puppeteer dependencies
+FROM ${base_image}:${base_image_tag}
+ENV NODE_MAJOR=22
+
+# install node
+RUN <<EOF 
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+apt-get update && apt-get install nodejs -y
+EOF
+
+# Install Puppeteer dependencies
 RUN apt-get update && apt-get install -y \
-ffmpeg \
 libnss3 \
 libatk1.0-0 \
 libatk-bridge2.0-0 \
@@ -13,7 +25,7 @@ libxcomposite1 \
 libxdamage1 \
 libxrandr2 \
 libgbm1 \
-libasound2 \
+libasound2t64 \
 && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -28,5 +40,4 @@ COPY logo/*.png /app/logo/
 
 # Use STREAM_PORT environment variable for dynamic port
 EXPOSE $STREAM_PORT
-CMD ["node", "index.js"]
-
+ENTRYPOINT ["node", "index.js"]


### PR DESCRIPTION
Helps with #11 

This switches to a base image that I maintain for another project at https://github.com/ErsatzTV/ErsatzTV-ffmpeg - the multi-platform image has ffmpeg 7.1.1 and wide hardware accel support (Intel VAAPI, AMD VAAPI, Intel QSV, NVIDIA).

I also made the ffmpeg video output settings an env var so you can customize them to use a hardware encoder, if desired.

To test with NVIDIA, I included `--gpus all` on my run command, as well as the env var `-e "VIDEO_OPTIONS=-c:v h264_nvenc -pix_fmt yuv420p -b:v 2000k"`.