### PR TITLE
Adjust viewport since wsk4p@6.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,7 +214,7 @@ async function startTranscoding() {
       }
       const screenshot = await page.screenshot({
         type: 'jpeg',
-        clip: { x: 11, y: 40, width: 631, height: 480 }
+        clip: { x: 4, y: 47, width: 631, height: 480 }
       });
       ffmpegStream.write(screenshot);
     } catch (err) {


### PR DESCRIPTION
 - Since the release of v6.0.0, the viewport has shifted to show some white borders and cut off some temperature numbers on one of the graphs.
 - This adjustment re-centers it to a somewhat appropriate degree (but shouldn't be considered exact)