### PR TITLE
Fix XMLTV generation

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ function generateXMLTV(host) {
     const start = startTime.toISOString().replace(/[-:T]/g, '').split('.')[0] + ' +0000';
     const end = endTime.toISOString().replace(/[-:T]/g, '').split('.')[0] + ' +0000';
     xml += `
-<programme start="${start}" end="${end}" channel="WS4000">
+<programme start="${start}" stop="${end}" channel="WS4000">
 <title lang="en">Local Weather</title>
 <desc lang="en">Enjoy your local weather with a touch of nostalgia.</desc>
 <icon src="${baseUrl}/logo/ws4000.png" />


### PR DESCRIPTION
XML-TV actually calls this field "stop" not "end".  This is causing a number of other systems like xTeVe, Telly, Threadfin, Plex, etc. from properly working with the guide data.

See https://wiki.xmltv.org/index.php/XMLTVFormat

I don't have Channels DVR myself but i'd be shocked if it chokes on this change.