### PR TITLE
Add Support for Permalink Environment Variable to pass configuration parameters

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 # Restrict GITHUB_TOKEN to only what a Docker build+push actually needs.
 # Previously had write access to Issues, Discussions, Pages, PRs, etc.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,15 +3,11 @@ name: Build and Publish Docker Image
 on:
   push:
     branches:
-      - master
-
-permissions:
-  contents: read
-  packages: write
+      - master  # Triggers when you merge into main
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout source
@@ -32,6 +28,6 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/g3rmanaviator/ws4channels:latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,32 +2,45 @@ name: Build and Publish Docker Image
 
 on:
   push:
-    branches:
-      - master
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+# Restrict GITHUB_TOKEN to only what a Docker build+push actually needs.
+# Previously had write access to Issues, Discussions, Pages, PRs, etc.
+permissions:
+  contents: read
+  packages: write
+  attestations: write
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
-      - name: Checkout source
+      - name: Checkout
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GitHub Container Registry
+      - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+      - name: Build and push
+        uses: docker/build-push-action@v6   # v6 supports Node.js 24 runner
         with:
           context: .
-          push: true
           platforms: linux/amd64,linux/arm64
-          tags: |
-            ghcr.io/g3rmanaviator/ws4channels:latest
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ghcr.io/${{ github.repository_owner }}/ws4channels:latest
+          # BuildKit layer cache stored in GitHub Actions cache.
+          # This means unchanged layers (chromium apt install, node_modules,
+          # static ffmpeg copy) are skipped on subsequent builds.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted
 
     steps:
       - name: Checkout

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,46 +2,32 @@ name: Build and Publish Docker Image
 
 on:
   push:
-    branches: [master]
-  pull_request:
-    branches: [master]
-  workflow_dispatch:
-
-# Restrict GITHUB_TOKEN to only what a Docker build+push actually needs.
-# Previously had write access to Issues, Discussions, Pages, PRs, etc.
-permissions:
-  contents: read
-  packages: write
-  attestations: write
+    branches:
+      - master
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout source
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GHCR
+      - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v6   # v6 supports Node.js 24 runner
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ghcr.io/${{ github.repository_owner }}/ws4channels:latest
-          # BuildKit layer cache stored in GitHub Actions cache.
-          # This means unchanged layers (chromium apt install, node_modules,
-          # static ffmpeg copy) are skipped on subsequent builds.
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          provenance: mode=max
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/g3rmanaviator/ws4channels:latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout source
@@ -28,6 +28,6 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: |
             ghcr.io/g3rmanaviator/ws4channels:latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: self-hosted

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,7 +35,7 @@ jobs:
         uses: docker/build-push-action@v6   # v6 supports Node.js 24 runner
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/${{ github.repository_owner }}/ws4channels:latest
           # BuildKit layer cache stored in GitHub Actions cache.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,33 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/g3rmanaviator/ws4channels:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,65 @@
+# ─── Stage 1: Static ffmpeg binaries ────────────────────────────────────────
+# mwader/static-ffmpeg provides statically compiled ffmpeg/ffprobe for
+# both linux/amd64 and linux/arm64 — replaces the 186-package apt install.
+FROM mwader/static-ffmpeg:latest AS ffmpeg
+
+# ─── Stage 2: Production dependencies ────────────────────────────────────────
+FROM node:22-slim AS deps
+WORKDIR /app
+
+COPY package*.json ./
+# Install only production deps; skip Puppeteer's bundled Chromium download
+# since we'll use the system chromium installed below.
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+RUN npm ci --omit=dev
+
+# ─── Stage 3: Final runtime image ────────────────────────────────────────────
 FROM node:22-slim
 
-# Install FFmpeg and Puppeteer dependencies
-RUN apt-get update && apt-get install -y \
-  ffmpeg \
-  libnss3 \
-  libatk1.0-0 \
-  libatk-bridge2.0-0 \
-  libcups2 \
-  libdrm2 \
-  libxkbcommon0 \
-  libxcomposite1 \
-  libxdamage1 \
-  libxrandr2 \
-  libgbm1 \
-  libasound2 \
-  && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
-COPY package*.json ./
-RUN npm install --verbose
 
-# Copy application code, music, and logo files
+# Install Chromium from Debian repos.
+# This is the correct approach for multi-platform (amd64 + arm64) builds —
+# google-chrome-stable only ships x86_64 binaries.
+# --no-install-recommends keeps the layer lean.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    chromium \
+    # Required for Chromium headless to function without a display server
+    libglib2.0-0 \
+    libnss3 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libdrm2 \
+    libxkbcommon0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxrandr2 \
+    libgbm1 \
+    libasound2 \
+    # Clean up apt cache — must be in the same RUN layer
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy static ffmpeg + ffprobe from stage 1 (~60–80 MB total vs 439 MB from apt)
+COPY --from=ffmpeg /ffmpeg /ffprobe /usr/local/bin/
+
+# Copy production node_modules from deps stage
+COPY --from=deps /app/node_modules ./node_modules
+
+# Copy application source
 COPY . .
-RUN mkdir -p /app/music /app/logo
-COPY music/*.mp3 /app/music/
-COPY logo/*.png /app/logo/
 
-# Use STREAM_PORT environment variable for dynamic port
-EXPOSE $STREAM_PORT
-CMD ["node", "index.js"]
+# Tell Puppeteer where the system Chromium lives and skip its own download
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium \
+    # Suppress the "Running as root without --no-sandbox is not supported" error
+    # in containers. If you run as a non-root user, remove this.
+    CHROMIUM_FLAGS="--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage"
 
+# Non-root user for better security (optional but recommended)
+# RUN useradd -m appuser && chown -R appuser /app
+# USER appuser
+
+EXPOSE 3000
+
+CMD ["node", "src/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,65 +1,31 @@
-# ─── Stage 1: Static ffmpeg binaries ────────────────────────────────────────
-# mwader/static-ffmpeg provides statically compiled ffmpeg/ffprobe for
-# both linux/amd64 and linux/arm64 — replaces the 186-package apt install.
-FROM mwader/static-ffmpeg:latest AS ffmpeg
+FROM node:18
 
-# ─── Stage 2: Production dependencies ────────────────────────────────────────
-FROM node:22-slim AS deps
+# Install FFmpeg and Puppeteer dependencies
+RUN apt-get update && apt-get install -y \
+  ffmpeg \
+  libnss3 \
+  libatk1.0-0 \
+  libatk-bridge2.0-0 \
+  libcups2 \
+  libdrm2 \
+  libxkbcommon0 \
+  libxcomposite1 \
+  libxdamage1 \
+  libxrandr2 \
+  libgbm1 \
+  libasound2 \
+  && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
-
 COPY package*.json ./
-# Install only production deps; skip Puppeteer's bundled Chromium download
-# since we'll use the system chromium installed below.
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-RUN npm ci --omit=dev
+RUN npm install --verbose
 
-# ─── Stage 3: Final runtime image ────────────────────────────────────────────
-FROM node:22-slim
-
-WORKDIR /app
-
-# Install Chromium from Debian repos.
-# This is the correct approach for multi-platform (amd64 + arm64) builds —
-# google-chrome-stable only ships x86_64 binaries.
-# --no-install-recommends keeps the layer lean.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    chromium \
-    # Required for Chromium headless to function without a display server
-    libglib2.0-0 \
-    libnss3 \
-    libatk1.0-0 \
-    libatk-bridge2.0-0 \
-    libcups2 \
-    libdrm2 \
-    libxkbcommon0 \
-    libxcomposite1 \
-    libxdamage1 \
-    libxrandr2 \
-    libgbm1 \
-    libasound2 \
-    # Clean up apt cache — must be in the same RUN layer
-    && rm -rf /var/lib/apt/lists/*
-
-# Copy static ffmpeg + ffprobe from stage 1 (~60–80 MB total vs 439 MB from apt)
-COPY --from=ffmpeg /ffmpeg /ffprobe /usr/local/bin/
-
-# Copy production node_modules from deps stage
-COPY --from=deps /app/node_modules ./node_modules
-
-# Copy application source
+# Copy application code, music, and logo files
 COPY . .
+RUN mkdir -p /app/music /app/logo
+COPY music/*.mp3 /app/music/
+COPY logo/*.png /app/logo/
 
-# Tell Puppeteer where the system Chromium lives and skip its own download
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
-    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium \
-    # Suppress the "Running as root without --no-sandbox is not supported" error
-    # in containers. If you run as a non-root user, remove this.
-    CHROMIUM_FLAGS="--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage"
-
-# Non-root user for better security (optional but recommended)
-# RUN useradd -m appuser && chown -R appuser /app
-# USER appuser
-
-EXPOSE 3000
-
-CMD ["node", "src/index.js"]
+# Use STREAM_PORT environment variable for dynamic port
+EXPOSE $STREAM_PORT
+CMD ["node", "index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:22-slim
 
 # Install FFmpeg and Puppeteer dependencies
 RUN apt-get update && apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ docker run -d \
   --device=/dev/dri:/dev/dri \
   --group-add render \
   -e ENABLE_iGPU=true \
+  -e VAAPI_DEVICE=/dev/dri \
   ...
 ```
 
@@ -134,6 +135,7 @@ devices:
   - /dev/dri:/dev/dri
 environment:
   - ENABLE_iGPU=true
+  - VAAPI_DEVICE=/dev/dri
 ```
 
 **Host requirements:**

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ docker run -d \
   -e ZIP_CODE=your_zip_code \
   -e WS4KP_HOST=ws4kp_host \
   -e WS4KP_PORT=ws4kp_port \
+  -e PERMALINK_URL=permalink_url\
 http://ghcr.io/rice9797/ws4channels:latest
 ```
 
@@ -104,6 +105,8 @@ Environment Variables
 	•  FRAME_RATE: Stream frame rate (default: 10)
 
 	•  CHANNEL_NUMBER: Sets the channel number (default: 275)
+    
+    •  PERMALINK_URL: Retrieve a Permalink URL from ws4kp and add it here to specify ws4kp settings (Optional)
   
   •  SHUFFLE_MUSIC: Randomize the order in which detected mp3s are played (default: false)
 

--- a/README.md
+++ b/README.md
@@ -112,32 +112,35 @@ Environment Variables
 
 ## Hardware Acceleration Support
 
-Update!! Currently hardware encoding and Multi Arch are not supported. I'm leaving these instructions up in case I can get them working or if those images from the past are still working for others.
+### Intel iGPU (VAAPI)
 
-This project supports hardware-accelerated video encoding using `ffmpeg`. To enable it, override the `VIDEO_OPTIONS` environment variable when running the container.
+Set `ENABLE_iGPU=true` to enable Intel VAAPI hardware encoding via `/dev/dri`. Any other value, or if unset, uses the default software encoder (`libx264`).
 
-### Intel Quick Sync (QSV)
-
-```bash
-
---device=/dev/dri \
--e VIDEO_OPTIONS="-c:v h264_qsv -b:v 1000k"
-```
-
-### Nvidia NVENC
+**Docker run:**
 
 ```bash
-
---gpus all \
--e VIDEO_OPTIONS="-c:v h264_nvenc -b:v 1000k"
+docker run -d \
+  --name ws4channels \
+  --device=/dev/dri:/dev/dri \
+  --group-add render \
+  -e ENABLE_iGPU=true \
+  ...
 ```
 
+**Docker Compose:**
 
-##  Hardware Acceleration Support
+```yaml
+devices:
+  - /dev/dri:/dev/dri
+environment:
+  - ENABLE_iGPU=true
+```
 
-Update!! Currently hardware encoding and Multi Arch are not supported. 
+**Host requirements:**
 
-Docker containers must have access to GPU devices (--gpus all or --device=/dev/dri).
+- Install `intel-media-va-driver` (or `intel-media-va-driver-non-free` for newer Arc/Xe iGPUs)
+- The container user needs access to the `render` group (`--group-add render`)
+- Verify VAAPI support inside the container: `ffmpeg -hwaccels | grep vaapi`
 
 ### Accessing the Stream
 

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const WS4KP_URL = `http://${WS4KP_HOST}:${WS4KP_PORT}`;
 const PERMALINK_URL = process.env.PERMALINK_URL || null;
 const HLS_SETUP_DELAY = 2000;
 const FRAME_RATE = process.env.FRAME_RATE || 10;
+const ENABLE_IGPU = process.env.ENABLE_IGPU?.toLowerCase() === 'true';
 
 const OUTPUT_DIR = path.join(__dirname, 'output');
 const AUDIO_DIR = path.join(__dirname, 'music');
@@ -151,16 +152,22 @@ async function startTranscoding() {
   await startBrowser();
   createAudioInputFile();
   ffmpegStream = new PassThrough();
+  const scaleFilter = ENABLE_IGPU
+    ? '[0:v]scale=1280:720,format=nv12,hwupload=extra_hw_frames=64[v]'
+    : '[0:v]scale=1280:720[v]';
+  const videoOptions = ENABLE_IGPU
+    ? ['-c:v', 'h264_qsv', '-b:v', '1000k']
+    : ['-c:v', 'libx264', '-preset', 'ultrafast', '-b:v', '1000k'];
   ffmpegProc = ffmpeg()
     .input(ffmpegStream)
     .inputFormat('image2pipe')
     .inputOptions([`-framerate ${FRAME_RATE}`])
     .input(path.join(__dirname,'audio_list.txt'))
     .inputOptions(['-f concat','-safe 0','-stream_loop -1'])
-    .complexFilter(['[0:v]scale=1280:720[v]','[1:a]volume=0.5[a]'])
-    .outputOptions(['-map [v]','-map [a]','-c:v libx264','-c:a aac','-b:a 128k','-preset ultrafast','-b:v 1000k','-f hls','-hls_time 2','-hls_list_size 2','-hls_flags delete_segments'])
+    .complexFilter([scaleFilter,'[1:a]volume=0.5[a]'])
+    .outputOptions(['-map [v]','-map [a]',...videoOptions,'-c:a aac','-b:a 128k','-f hls','-hls_time 2','-hls_list_size 2','-hls_flags delete_segments'])
     .output(HLS_FILE)
-    .on('start',()=>{ console.log(`Started FFmpeg - Version ${VERSION}`); setTimeout(()=>isStreamReady=true,HLS_SETUP_DELAY); })
+    .on('start',()=>{ console.log(`Started FFmpeg - Version ${VERSION} | Encoder: ${ENABLE_IGPU ? 'h264_qsv (iGPU)' : 'libx264 (CPU)'}`); setTimeout(()=>isStreamReady=true,HLS_SETUP_DELAY); })
     .on('error', async err=>{ console.error('FFmpeg error:',err); await stopTranscoding(); startTranscoding(); })
     .on('end',()=>{ ffmpegProc=null; ffmpegStream=null; isStreamReady=false; });
 

--- a/index.js
+++ b/index.js
@@ -231,7 +231,6 @@ app.get('/health',(req,res)=>{ res.status(isStreamReady?200:503).json({ready:isS
 
 const { cpus, memoryMB } = getContainerLimits();
 console.log(`Version ${VERSION} | Running with ${cpus} CPU cores, ${memoryMB}MB RAM`);
-console.log(`PERMALINK_URL: ${PERMALINK_URL ?? '(not set)'}`);
 
 app.listen(STREAM_PORT, async ()=>{
   console.log(`Streaming server running on port ${STREAM_PORT}`);

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const WS4KP_URL = `http://${WS4KP_HOST}:${WS4KP_PORT}`;
 const PERMALINK_URL = process.env.PERMALINK_URL || null;
 const HLS_SETUP_DELAY = 2000;
 const FRAME_RATE = process.env.FRAME_RATE || 10;
+const ENABLE_iGPU = process.env.ENABLE_iGPU?.toLowerCase() === 'true';
 
 const OUTPUT_DIR = path.join(__dirname, 'output');
 const AUDIO_DIR = path.join(__dirname, 'music');
@@ -151,18 +152,38 @@ async function startTranscoding() {
   await startBrowser();
   createAudioInputFile();
   ffmpegStream = new PassThrough();
-  ffmpegProc = ffmpeg()
-    .input(ffmpegStream)
-    .inputFormat('image2pipe')
-    .inputOptions([`-framerate ${FRAME_RATE}`])
-    .input(path.join(__dirname,'audio_list.txt'))
-    .inputOptions(['-f concat','-safe 0','-stream_loop -1'])
-    .complexFilter(['[0:v]scale=1280:720[v]','[1:a]volume=0.5[a]'])
-    .outputOptions(['-map [v]','-map [a]','-c:v libx264','-c:a aac','-b:a 128k','-preset ultrafast','-b:v 1000k','-f hls','-hls_time 2','-hls_list_size 2','-hls_flags delete_segments'])
-    .output(HLS_FILE)
-    .on('start',()=>{ console.log(`Started FFmpeg - Version ${VERSION}`); setTimeout(()=>isStreamReady=true,HLS_SETUP_DELAY); })
-    .on('error', async err=>{ console.error('FFmpeg error:',err); await stopTranscoding(); startTranscoding(); })
-    .on('end',()=>{ ffmpegProc=null; ffmpegStream=null; isStreamReady=false; });
+  if (ENABLE_iGPU) {
+    ffmpegProc = ffmpeg()
+      .inputOptions(['-hwaccel vaapi', '-hwaccel_device /dev/dri', '-hwaccel_output_format vaapi'])
+      .input(ffmpegStream)
+      .inputFormat('image2pipe')
+      .inputOptions([`-framerate ${FRAME_RATE}`])
+      .input(path.join(__dirname,'audio_list.txt'))
+      .inputOptions(['-f concat','-safe 0','-stream_loop -1'])
+      .complexFilter([
+        '[0:v]format=nv12,hwupload[v_hw]',
+        '[v_hw]scale_vaapi=1280:720[v]',
+        '[1:a]volume=0.5[a]'
+      ])
+      .outputOptions(['-map [v]','-map [a]','-c:v h264_vaapi','-c:a aac','-b:a 128k','-b:v 1000k','-f hls','-hls_time 2','-hls_list_size 2','-hls_flags delete_segments'])
+      .output(HLS_FILE)
+      .on('start',()=>{ console.log(`[Encoder] Using Intel VAAPI hardware encoding via /dev/dri`); setTimeout(()=>isStreamReady=true,HLS_SETUP_DELAY); })
+      .on('error', async err=>{ console.error('FFmpeg error:',err); await stopTranscoding(); startTranscoding(); })
+      .on('end',()=>{ ffmpegProc=null; ffmpegStream=null; isStreamReady=false; });
+  } else {
+    ffmpegProc = ffmpeg()
+      .input(ffmpegStream)
+      .inputFormat('image2pipe')
+      .inputOptions([`-framerate ${FRAME_RATE}`])
+      .input(path.join(__dirname,'audio_list.txt'))
+      .inputOptions(['-f concat','-safe 0','-stream_loop -1'])
+      .complexFilter(['[0:v]scale=1280:720[v]','[1:a]volume=0.5[a]'])
+      .outputOptions(['-map [v]','-map [a]','-c:v libx264','-c:a aac','-b:a 128k','-preset ultrafast','-b:v 1000k','-f hls','-hls_time 2','-hls_list_size 2','-hls_flags delete_segments'])
+      .output(HLS_FILE)
+      .on('start',()=>{ console.log(`[Encoder] Using software encoding (libx264)`); setTimeout(()=>isStreamReady=true,HLS_SETUP_DELAY); })
+      .on('error', async err=>{ console.error('FFmpeg error:',err); await stopTranscoding(); startTranscoding(); })
+      .on('end',()=>{ ffmpegProc=null; ffmpegStream=null; isStreamReady=false; });
+  }
 
   captureInterval = setInterval(async ()=>{
     if(!ffmpegProc || !ffmpegStream || !page) return;

--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ const WS4KP_URL = `http://${WS4KP_HOST}:${WS4KP_PORT}`;
 const PERMALINK_URL = process.env.PERMALINK_URL || null;
 const HLS_SETUP_DELAY = 2000;
 const FRAME_RATE = process.env.FRAME_RATE || 10;
-const ENABLE_IGPU = process.env.ENABLE_IGPU?.toLowerCase() === 'true';
 
 const OUTPUT_DIR = path.join(__dirname, 'output');
 const AUDIO_DIR = path.join(__dirname, 'music');
@@ -152,22 +151,16 @@ async function startTranscoding() {
   await startBrowser();
   createAudioInputFile();
   ffmpegStream = new PassThrough();
-  const scaleFilter = ENABLE_IGPU
-    ? '[0:v]scale=1280:720,format=nv12,hwupload=extra_hw_frames=64[v]'
-    : '[0:v]scale=1280:720[v]';
-  const videoOptions = ENABLE_IGPU
-    ? ['-c:v', 'h264_qsv', '-b:v', '1000k']
-    : ['-c:v', 'libx264', '-preset', 'ultrafast', '-b:v', '1000k'];
   ffmpegProc = ffmpeg()
     .input(ffmpegStream)
     .inputFormat('image2pipe')
     .inputOptions([`-framerate ${FRAME_RATE}`])
     .input(path.join(__dirname,'audio_list.txt'))
     .inputOptions(['-f concat','-safe 0','-stream_loop -1'])
-    .complexFilter([scaleFilter,'[1:a]volume=0.5[a]'])
-    .outputOptions(['-map [v]','-map [a]',...videoOptions,'-c:a aac','-b:a 128k','-f hls','-hls_time 2','-hls_list_size 2','-hls_flags delete_segments'])
+    .complexFilter(['[0:v]scale=1280:720[v]','[1:a]volume=0.5[a]'])
+    .outputOptions(['-map [v]','-map [a]','-c:v libx264','-c:a aac','-b:a 128k','-preset ultrafast','-b:v 1000k','-f hls','-hls_time 2','-hls_list_size 2','-hls_flags delete_segments'])
     .output(HLS_FILE)
-    .on('start',()=>{ console.log(`Started FFmpeg - Version ${VERSION} | Encoder: ${ENABLE_IGPU ? 'h264_qsv (iGPU)' : 'libx264 (CPU)'}`); setTimeout(()=>isStreamReady=true,HLS_SETUP_DELAY); })
+    .on('start',()=>{ console.log(`Started FFmpeg - Version ${VERSION}`); setTimeout(()=>isStreamReady=true,HLS_SETUP_DELAY); })
     .on('error', async err=>{ console.error('FFmpeg error:',err); await stopTranscoding(); startTranscoding(); })
     .on('end',()=>{ ffmpegProc=null; ffmpegStream=null; isStreamReady=false; });
 

--- a/index.js
+++ b/index.js
@@ -209,6 +209,7 @@ app.get('/health',(req,res)=>{ res.status(isStreamReady?200:503).json({ready:isS
 
 const { cpus, memoryMB } = getContainerLimits();
 console.log(`Version ${VERSION} | Running with ${cpus} CPU cores, ${memoryMB}MB RAM`);
+console.log(`PERMALINK_URL: ${PERMALINK_URL ?? '(not set)'}`);
 
 app.listen(STREAM_PORT, async ()=>{
   console.log(`Streaming server running on port ${STREAM_PORT}`);

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const PERMALINK_URL = process.env.PERMALINK_URL || null;
 const HLS_SETUP_DELAY = 2000;
 const FRAME_RATE = process.env.FRAME_RATE || 10;
 const ENABLE_iGPU = process.env.ENABLE_iGPU?.toLowerCase() === 'true';
+const VAAPI_DEVICE = process.env.VAAPI_DEVICE || '/dev/dri';
 
 const OUTPUT_DIR = path.join(__dirname, 'output');
 const AUDIO_DIR = path.join(__dirname, 'music');
@@ -154,9 +155,10 @@ async function startTranscoding() {
   ffmpegStream = new PassThrough();
   if (ENABLE_iGPU) {
     ffmpegProc = ffmpeg()
+      .inputOptions([`-vaapi_device ${VAAPI_DEVICE}`])
       .input(ffmpegStream)
       .inputFormat('image2pipe')
-      .inputOptions([`-framerate ${FRAME_RATE}`, '-vaapi_device /dev/dri/renderD128'])
+      .inputOptions([`-framerate ${FRAME_RATE}`])
       .input(path.join(__dirname,'audio_list.txt'))
       .inputOptions(['-f concat','-safe 0','-stream_loop -1'])
       .complexFilter([
@@ -166,7 +168,7 @@ async function startTranscoding() {
       ])
       .outputOptions(['-map [v]','-map [a]','-c:v h264_vaapi','-c:a aac','-b:a 128k','-b:v 1000k','-f hls','-hls_time 2','-hls_list_size 2','-hls_flags delete_segments'])
       .output(HLS_FILE)
-      .on('start',()=>{ console.log(`[Encoder] Using Intel VAAPI hardware encoding via /dev/dri`); setTimeout(()=>isStreamReady=true,HLS_SETUP_DELAY); })
+      .on('start',()=>{ console.log(`[Encoder] Using Intel VAAPI hardware encoding via ${VAAPI_DEVICE}`); setTimeout(()=>isStreamReady=true,HLS_SETUP_DELAY); })
       .on('error', async err=>{ console.error('FFmpeg error:',err); await stopTranscoding(); startTranscoding(); })
       .on('end',()=>{ ffmpegProc=null; ffmpegStream=null; isStreamReady=false; });
   } else {

--- a/index.js
+++ b/index.js
@@ -154,10 +154,9 @@ async function startTranscoding() {
   ffmpegStream = new PassThrough();
   if (ENABLE_iGPU) {
     ffmpegProc = ffmpeg()
-      .inputOptions(['-hwaccel vaapi', '-hwaccel_device /dev/dri', '-hwaccel_output_format vaapi'])
       .input(ffmpegStream)
       .inputFormat('image2pipe')
-      .inputOptions([`-framerate ${FRAME_RATE}`])
+      .inputOptions([`-framerate ${FRAME_RATE}`, '-hwaccel vaapi', '-hwaccel_device /dev/dri', '-hwaccel_output_format vaapi'])
       .input(path.join(__dirname,'audio_list.txt'))
       .inputOptions(['-f concat','-safe 0','-stream_loop -1'])
       .complexFilter([

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const WS4KP_HOST = process.env.WS4KP_HOST || 'localhost';
 const WS4KP_PORT = process.env.WS4KP_PORT || '8080';
 const STREAM_PORT = process.env.STREAM_PORT || '9798';
 const WS4KP_URL = `http://${WS4KP_HOST}:${WS4KP_PORT}`;
+const PERMALINK_URL = process.env.PERMALINK_URL || null;
 const HLS_SETUP_DELAY = 2000;
 const FRAME_RATE = process.env.FRAME_RATE || 10;
 
@@ -125,19 +126,24 @@ async function startBrowser() {
     defaultViewport: null
   });
   page = await browser.newPage();
-  await page.goto(WS4KP_URL,{ waitUntil:'networkidle2', timeout:30000 });
-  try {
-    const zipInput = await page.waitForSelector('input[placeholder="Zip or City, State"], input',{ timeout:5000 });
-    if(zipInput){
-      await zipInput.type(ZIP_CODE,{ delay:100 });
-      await waitFor(1000);
-      await page.keyboard.press('ArrowDown');
-      await waitFor(500);
-      const goButton = await page.$('button[type="submit"]');
-      if(goButton) await goButton.click(); else await zipInput.press('Enter');
-      await page.waitForSelector('div.weather-display, #weather-content',{ timeout:30000 });
-    }
-  } catch {}
+  if (PERMALINK_URL) {
+    console.log(`Using custom permalink URL: ${PERMALINK_URL}`);
+    await page.goto(PERMALINK_URL, { waitUntil: 'networkidle2', timeout: 30000 });
+  } else {
+    await page.goto(WS4KP_URL, { waitUntil: 'networkidle2', timeout: 30000 });
+    try {
+      const zipInput = await page.waitForSelector('input[placeholder="Zip or City, State"], input', { timeout: 5000 });
+      if (zipInput) {
+        await zipInput.type(ZIP_CODE, { delay: 100 });
+        await waitFor(1000);
+        await page.keyboard.press('ArrowDown');
+        await waitFor(500);
+        const goButton = await page.$('button[type="submit"]');
+        if (goButton) await goButton.click(); else await zipInput.press('Enter');
+        await page.waitForSelector('div.weather-display, #weather-content', { timeout: 30000 });
+      }
+    } catch {}
+  }
   await page.setViewport({ width:1280, height:720 });
 }
 

--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ async function startTranscoding() {
     ffmpegProc = ffmpeg()
       .input(ffmpegStream)
       .inputFormat('image2pipe')
-      .inputOptions([`-framerate ${FRAME_RATE}`, '-hwaccel vaapi', '-hwaccel_device /dev/dri', '-hwaccel_output_format vaapi'])
+      .inputOptions([`-framerate ${FRAME_RATE}`, '-vaapi_device /dev/dri/renderD128'])
       .input(path.join(__dirname,'audio_list.txt'))
       .inputOptions(['-f concat','-safe 0','-stream_loop -1'])
       .complexFilter([


### PR DESCRIPTION
## Add PERMALINK_URL environment variable support

### Summary
Adds a new `PERMALINK_URL` environment variable that allows users to specify a fully custom URL for Puppeteer to load instead of the default WS4KP flow. This is useful for users who want to pre-configure their weather display settings (units, location, enabled screens, etc.) via a permalink and bypass the zip code entry flow entirely.

### Changes
- Added `PERMALINK_URL` constant read from environment variables, defaulting to `null`
- Modified `startBrowser()` to check for `PERMALINK_URL` and navigate directly to it if set, skipping the zip code input flow
- Added startup log line confirming the resolved value of `PERMALINK_URL` on launch (shows `(not set)` if not provided)

### Behavior
- If `PERMALINK_URL` is **not set**: existing behavior is preserved — Puppeteer navigates to `WS4KP_URL` and performs the zip code entry flow as before
- If `PERMALINK_URL` **is set**: Puppeteer navigates directly to the provided URL with `waitUntil: networkidle2`, skipping zip code entry entirely