### PR TITLE
Add Support for Permalink Environment Variable to pass configuration parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ Environment Variables
 
 	•  CHANNEL_NUMBER: Sets the channel number (default: 275)
   
-  •  SHUFFLE_MUSIC: Randomize the order in which detected mp3s are played (default: false)
+    •  SHUFFLE_MUSIC: Randomize the order in which detected mp3s are played (default: false)
   
-  • PERMALINK_URL: Pass configuration parameters via permalink generated from ws4kp
+    •  PERMALINK_URL: Pass configuration parameters via permalink generated from ws4kp
 
 ## Hardware Acceleration Support
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Environment Variables
 	•  CHANNEL_NUMBER: Sets the channel number (default: 275)
   
   •  SHUFFLE_MUSIC: Randomize the order in which detected mp3s are played (default: false)
+  
+  • PERMALINK_URL: Pass configuration parameters via permalink generated from ws4kp
 
 ## Hardware Acceleration Support
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const WS4KP_HOST = process.env.WS4KP_HOST || 'localhost';
 const WS4KP_PORT = process.env.WS4KP_PORT || '8080';
 const STREAM_PORT = process.env.STREAM_PORT || '9798';
 const WS4KP_URL = `http://${WS4KP_HOST}:${WS4KP_PORT}`;
+const PERMALINK_URL = process.env.PERMALINK_URL || null;
 const HLS_SETUP_DELAY = 2000;
 const FRAME_RATE = process.env.FRAME_RATE || 10;
 
@@ -125,19 +126,24 @@ async function startBrowser() {
     defaultViewport: null
   });
   page = await browser.newPage();
-  await page.goto(WS4KP_URL,{ waitUntil:'networkidle2', timeout:30000 });
-  try {
-    const zipInput = await page.waitForSelector('input[placeholder="Zip or City, State"], input',{ timeout:5000 });
-    if(zipInput){
-      await zipInput.type(ZIP_CODE,{ delay:100 });
-      await waitFor(1000);
-      await page.keyboard.press('ArrowDown');
-      await waitFor(500);
-      const goButton = await page.$('button[type="submit"]');
-      if(goButton) await goButton.click(); else await zipInput.press('Enter');
-      await page.waitForSelector('div.weather-display, #weather-content',{ timeout:30000 });
-    }
-  } catch {}
+  if (PERMALINK_URL) {
+    console.log(`Using custom permalink URL: ${PERMALINK_URL}`);
+    await page.goto(PERMALINK_URL, { waitUntil: 'networkidle2', timeout: 30000 });
+  } else {
+    await page.goto(WS4KP_URL, { waitUntil: 'networkidle2', timeout: 30000 });
+    try {
+      const zipInput = await page.waitForSelector('input[placeholder="Zip or City, State"], input', { timeout: 5000 });
+      if (zipInput) {
+        await zipInput.type(ZIP_CODE, { delay: 100 });
+        await waitFor(1000);
+        await page.keyboard.press('ArrowDown');
+        await waitFor(500);
+        const goButton = await page.$('button[type="submit"]');
+        if (goButton) await goButton.click(); else await zipInput.press('Enter');
+        await page.waitForSelector('div.weather-display, #weather-content', { timeout: 30000 });
+      }
+    } catch {}
+  }
   await page.setViewport({ width:1280, height:720 });
 }
 


### PR DESCRIPTION
## Add PERMALINK_URL environment variable support

### Summary
Adds a new `PERMALINK_URL` environment variable that allows users to specify a fully custom URL for Puppeteer to load instead of the default WS4KP flow. This is useful for users who want to pre-configure their weather display settings (units, location, enabled screens, etc.) via a permalink and bypass the zip code entry flow entirely.

### Changes
- Added `PERMALINK_URL` constant read from environment variables, defaulting to `null`
- Modified `startBrowser()` to check for `PERMALINK_URL` and navigate directly to it if set, skipping the zip code input flow
- Added startup log line confirming the resolved value of `PERMALINK_URL` on launch (shows `(not set)` if not provided)

### Behavior
- If `PERMALINK_URL` is **not set**: existing behavior is preserved — Puppeteer navigates to `WS4KP_URL` and performs the zip code entry flow as before
- If `PERMALINK_URL` **is set**: Puppeteer navigates directly to the provided URL with `waitUntil: networkidle2`, skipping zip code entry entirely