### PR TITLE
Ubuntu 24.04 upgrade + Intel iGPU encoding support + ws4kp-international support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,7 @@ name: Build and Publish Docker Image
 on:
   push:
     branches:
-      - merge
+      - iGPU
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,34 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches:
+      - ubuntu-24.04
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/g3rmanaviator/ws4channels:ubuntu-24

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,7 @@ name: Build and Publish Docker Image
 on:
   push:
     branches:
-      - ubuntu-24.04
+      - merge
   workflow_dispatch:
 
 jobs:
@@ -31,4 +31,4 @@ jobs:
           push: true
           platforms: linux/amd64
           tags: |
-            ghcr.io/g3rmanaviator/ws4channels:ubuntu-24
+            ghcr.io/g3rmanaviator/ws4channels:merge

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,11 @@ RUN mkdir -p /etc/apt/keyrings && \
 RUN apt-get update && apt-get install -y \
     ffmpeg \
     intel-media-va-driver-non-free \
-    libmfx-gen1 \
     libvpl2 \
-    libvpl-tools \
     libva2 \
     libva-drm2 \
     va-driver-all \
+    vainfo \
     libdrm2 \
     libgbm1 \
     libnss3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,28 +3,41 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LIBVA_DRIVER_NAME=iHD
 ENV PUPPETEER_SKIP_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable
 
 # Base packages
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     gnupg \
+    vainfo \
     pciutils \
     usbutils \
-    vainfo \
+    xdg-utils \
+    fonts-liberation \
     && rm -rf /var/lib/apt/lists/*
 
-# Node.js 22
-# NodeSource currently documents the Debian/Ubuntu repo flow for Node 22 installs.
+# Install Node.js 22
 RUN mkdir -p /etc/apt/keyrings && \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
       | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" \
       > /etc/apt/sources.list.d/nodesource.list && \
-    apt-get update && apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get update && apt-get install -y \
+      nodejs \
+      && rm -rf /var/lib/apt/lists/*
 
-# FFmpeg + Intel media stack + common runtime libs
+# Install Google Chrome
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://dl.google.com/linux/linux_signing_key.pub \
+      | gpg --dearmor -o /etc/apt/keyrings/google.gpg && \
+    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
+      > /etc/apt/sources.list.d/google-chrome.list && \
+    apt-get update && apt-get install -y \
+      google-chrome-stable \
+      && rm -rf /var/lib/apt/lists/*
+
+# FFmpeg + Intel media stack + Puppeteer/Chrome runtime deps
 RUN apt-get update && apt-get install -y \
     ffmpeg \
     intel-media-va-driver-non-free \
@@ -32,7 +45,6 @@ RUN apt-get update && apt-get install -y \
     libva2 \
     libva-drm2 \
     va-driver-all \
-    vainfo \
     libdrm2 \
     libgbm1 \
     libnss3 \
@@ -43,11 +55,16 @@ RUN apt-get update && apt-get install -y \
     libxcomposite1 \
     libxdamage1 \
     libxrandr2 \
-    libasound2t64 \
-    libxshmfence1 \
+    libxfixes3 \
+    libxext6 \
+    libx11-6 \
     libx11-xcb1 \
-    fonts-liberation \
-    xdg-utils \
+    libxcb1 \
+    libxshmfence1 \
+    libasound2t64 \
+    libglib2.0-0 \
+    libgtk-3-0 \
+    libnspr4 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -62,6 +79,6 @@ RUN mkdir -p /app/music /app/logo
 COPY music/*.mp3 /app/music/
 COPY logo/*.png /app/logo/
 
-EXPOSE 3000
+EXPOSE 9798
 
 CMD ["node", "index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,50 @@
 FROM node:22-noble
 
-# Install FFmpeg and Puppeteer dependencies
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LIBVA_DRIVER_NAME=iHD
+ENV PUPPETEER_SKIP_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
+# Install Node.js 18
+RUN apt-get update && apt-get install -y curl && \
+    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y nodejs
+
+# Install FFmpeg, Intel media drivers, and Puppeteer dependencies
 RUN apt-get update && apt-get install -y \
-  ffmpeg \
-  libnss3 \
-  libatk1.0-0 \
-  libatk-bridge2.0-0 \
-  libcups2 \
-  libdrm2 \
-  libxkbcommon0 \
-  libxcomposite1 \
-  libxdamage1 \
-  libxrandr2 \
-  libgbm1 \
-  libasound2t64 \
-  && rm -rf /var/lib/apt/lists/*
+    ffmpeg \
+    chromium-browser \
+    intel-media-va-driver-non-free \
+    libva-drm2 \
+    libva2 \
+    libnss3 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libdrm2 \
+    libxkbcommon0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxrandr2 \
+    libgbm1 \
+    libasound2t64 \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
+
 COPY package*.json ./
+
 RUN npm install --verbose
 
 # Copy application code, music, and logo files
 COPY . .
+
 RUN mkdir -p /app/music /app/logo
+
 COPY music/*.mp3 /app/music/
 COPY logo/*.png /app/logo/
 
 # Use STREAM_PORT environment variable for dynamic port
 EXPOSE $STREAM_PORT
-CMD ["node", "index.js"]
 
+CMD ["node", "index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,61 @@
-FROM node:22-noble
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LIBVA_DRIVER_NAME=iHD
 ENV PUPPETEER_SKIP_DOWNLOAD=true
-ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
-# Install Node.js 18
-RUN apt-get update && apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
-    apt-get install -y nodejs
+# Base packages
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    curl \
+    gnupg \
+    pciutils \
+    usbutils \
+    vainfo \
+    && rm -rf /var/lib/apt/lists/*
 
-# Install FFmpeg, Intel media drivers, and Puppeteer dependencies
+# Node.js 22
+# NodeSource currently documents the Debian/Ubuntu repo flow for Node 22 installs.
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+      | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" \
+      > /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# FFmpeg + Intel media stack + common runtime libs
 RUN apt-get update && apt-get install -y \
     ffmpeg \
-    chromium-browser \
     intel-media-va-driver-non-free \
-    libva-drm2 \
+    libmfx-gen1 \
+    libvpl2 \
+    libvpl-tools \
     libva2 \
+    libva-drm2 \
+    va-driver-all \
+    libdrm2 \
+    libgbm1 \
     libnss3 \
     libatk1.0-0 \
     libatk-bridge2.0-0 \
     libcups2 \
-    libdrm2 \
     libxkbcommon0 \
     libxcomposite1 \
     libxdamage1 \
     libxrandr2 \
-    libgbm1 \
     libasound2t64 \
+    libxshmfence1 \
+    libx11-xcb1 \
+    fonts-liberation \
+    xdg-utils \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
 COPY package*.json ./
-
 RUN npm install --verbose
 
-# Copy application code, music, and logo files
 COPY . .
 
 RUN mkdir -p /app/music /app/logo
@@ -44,7 +63,6 @@ RUN mkdir -p /app/music /app/logo
 COPY music/*.mp3 /app/music/
 COPY logo/*.png /app/logo/
 
-# Use STREAM_PORT environment variable for dynamic port
-EXPOSE $STREAM_PORT
+EXPOSE 3000
 
 CMD ["node", "index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:22-noble
 
 # Install FFmpeg and Puppeteer dependencies
 RUN apt-get update && apt-get install -y \
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y \
   libxdamage1 \
   libxrandr2 \
   libgbm1 \
-  libasound2 \
+  libasound2t64 \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ Environment Variables
 
 	•  CHANNEL_NUMBER: Sets the channel number (default: 275)
   
-  •  SHUFFLE_MUSIC: Randomize the order in which detected mp3s are played (default: false)
+    •  SHUFFLE_MUSIC: Randomize the order in which detected mp3s are played (default: false)
   
-  • PERMALINK_URL: Pass configuration parameters via permalink generated from ws4kp
+    •  PERMALINK_URL: Pass configuration parameters via permalink generated from ws4kp
 
 ## Hardware Acceleration Support
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Environment Variables
 	•  CHANNEL_NUMBER: Sets the channel number (default: 275)
   
   •  SHUFFLE_MUSIC: Randomize the order in which detected mp3s are played (default: false)
+  
+  • PERMALINK_URL: Pass configuration parameters via permalink generated from ws4kp
 
 ## Hardware Acceleration Support
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Latest Update
 
+04/06/2026
+- Upgraded base image to **Ubuntu 24.04**
+- Upgraded to **Node.js 22**
+- Updated audio library to `libasound2t64` (Ubuntu 24.04 renamed package)
+- Intel VAAPI driver stack (`intel-media-va-driver-non-free`, `libvpl2`, `libva2`) baked into the image
+- Added **Intel iGPU hardware encoding** support via VAAPI — enable with `ENABLE_IGPU=true` (amd64 only)
+- Added `WS4KP_INTERNATIONAL` variable for international display offset support
+- **Current build is amd64 only.** arm64 support is planned for a future release.
+
 03/07/2026
 Added widescreen as default output, randomized music, and expand guide data compatiability for other programs like xTeVe, Telly, Threadfin, Plex, Jellyfin ect.
 
@@ -107,36 +116,36 @@ Environment Variables
   
     •  SHUFFLE_MUSIC: Randomize the order in which detected mp3s are played (default: false)
   
-    •  PERMALINK_URL: Pass configuration parameters via permalink generated from ws4kp
+    •  PERMALINK_URL: Pass configuration parameters via permalink generated from ws4kp/ws4kp-international
+
+	•  WS4KP_INTERNATIONAL: Adjust crop offset when using ws4kp-international (default: false)
+
+	•  ENABLE_IGPU: Enable Intel iGPU hardware encoding via VAAPI (default: false, amd64 only)
 
 ## Hardware Acceleration Support
 
-Update!! Currently hardware encoding and Multi Arch are not supported. I'm leaving these instructions up in case I can get them working or if those images from the past are still working for others.
+Intel iGPU hardware encoding is supported on **amd64** hosts via VAAPI (`h264_vaapi`). This requires passing the `/dev/dri` device to the container and setting `ENABLE_IGPU=true`.
 
-This project supports hardware-accelerated video encoding using `ffmpeg`. To enable it, override the `VIDEO_OPTIONS` environment variable when running the container.
+If `ENABLE_IGPU=true` but `/dev/dri/renderD128` is not found, the container automatically falls back to CPU encoding (`libx264`) and logs a warning.
 
-### Intel Quick Sync (QSV)
+**arm64 and NVIDIA are not currently supported for hardware encoding.**
 
-```bash
-
---device=/dev/dri \
--e VIDEO_OPTIONS="-c:v h264_qsv -b:v 1000k"
-```
-
-### Nvidia NVENC
+### Intel iGPU (VAAPI) — amd64 only
 
 ```bash
-
---gpus all \
--e VIDEO_OPTIONS="-c:v h264_nvenc -b:v 1000k"
+docker run -d \
+  --name ws4channels \
+  --restart unless-stopped \
+  --memory="1096m" \
+  --cpus="1.0" \
+  --device=/dev/dri \
+  -p 9798:9798 \
+  -e ZIP_CODE=your_zip_code \
+  -e WS4KP_HOST=ws4kp_host \
+  -e WS4KP_PORT=ws4kp_port \
+  -e ENABLE_IGPU=true \
+  ghcr.io/rice9797/ws4channels:latest
 ```
-
-
-##  Hardware Acceleration Support
-
-Update!! Currently hardware encoding and Multi Arch are not supported. 
-
-Docker containers must have access to GPU devices (--gpus all or --device=/dev/dri).
 
 ### Accessing the Stream
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const PERMALINK_URL = process.env.PERMALINK_URL || null;
 const HLS_SETUP_DELAY = 2000;
 const FRAME_RATE = Number(process.env.FRAME_RATE || 10);
 const WS4KP_INTERNATIONAL = process.env.WS4KP_INTERNATIONAL?.toLowerCase() === 'true';
+const ENABLE_IGPU = process.env.ENABLE_IGPU?.toLowerCase() === 'true';
 const PUPPETEER_EXECUTABLE_PATH =
   process.env.PUPPETEER_EXECUTABLE_PATH || '/usr/bin/google-chrome-stable';
 
@@ -72,6 +73,10 @@ function getContainerLimits() {
   } catch {}
 
   return { cpus, memoryMB: Math.round(memory / (1024 * 1024)) };
+}
+
+function isVaapiAvailable() {
+  return fs.existsSync('/dev/dri/renderD128');
 }
 
 function createAudioInputFile() {
@@ -187,20 +192,31 @@ async function startTranscoding() {
 
   ffmpegStream = new PassThrough();
 
+  const useVaapi = ENABLE_IGPU && isVaapiAvailable();
+  if (ENABLE_IGPU && !useVaapi) console.warn('ENABLE_IGPU set but /dev/dri/renderD128 not found — falling back to libx264');
+  console.log(`Transcoding mode: ${useVaapi ? 'iGPU (h264_vaapi)' : 'CPU (libx264)'}`);
+
+  const vaapiInputOptions = useVaapi ? ['-vaapi_device /dev/dri/renderD128'] : [];
+  const videoComplexFilter = useVaapi
+    ? '[0:v]scale=1280:720,format=nv12,hwupload[v]'
+    : '[0:v]scale=1280:720[v]';
+  const videoCodecOptions = useVaapi
+    ? ['-c:v h264_vaapi']
+    : ['-c:v libx264', '-preset ultrafast'];
+
   ffmpegProc = ffmpeg()
     .input(ffmpegStream)
     .inputFormat('image2pipe')
-    .inputOptions([`-framerate ${FRAME_RATE}`])
+    .inputOptions([`-framerate ${FRAME_RATE}`, ...vaapiInputOptions])
     .input(path.join(__dirname, 'audio_list.txt'))
     .inputOptions(['-f concat', '-safe 0', '-stream_loop -1'])
-    .complexFilter(['[0:v]scale=1280:720[v]', '[1:a]volume=0.5[a]'])
+    .complexFilter([videoComplexFilter, '[1:a]volume=0.5[a]'])
     .outputOptions([
       '-map [v]',
       '-map [a]',
-      '-c:v libx264',
+      ...videoCodecOptions,
       '-c:a aac',
       '-b:a 128k',
-      '-preset ultrafast',
       '-b:v 1000k',
       '-f hls',
       '-hls_time 2',

--- a/index.js
+++ b/index.js
@@ -15,14 +15,18 @@ const WS4KP_PORT = process.env.WS4KP_PORT || '8080';
 const STREAM_PORT = process.env.STREAM_PORT || '9798';
 const WS4KP_URL = `http://${WS4KP_HOST}:${WS4KP_PORT}`;
 const HLS_SETUP_DELAY = 2000;
-const FRAME_RATE = process.env.FRAME_RATE || 10;
+const FRAME_RATE = Number(process.env.FRAME_RATE || 10);
+const PUPPETEER_EXECUTABLE_PATH =
+  process.env.PUPPETEER_EXECUTABLE_PATH || '/usr/bin/google-chrome-stable';
 
 const OUTPUT_DIR = path.join(__dirname, 'output');
 const AUDIO_DIR = path.join(__dirname, 'music');
 const LOGO_DIR = path.join(__dirname, 'logo');
 const HLS_FILE = path.join(OUTPUT_DIR, 'stream.m3u8');
 
-[OUTPUT_DIR, AUDIO_DIR, LOGO_DIR].forEach(dir => { if (!fs.existsSync(dir)) fs.mkdirSync(dir); });
+[OUTPUT_DIR, AUDIO_DIR, LOGO_DIR].forEach(dir => {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir);
+});
 
 app.use('/stream', express.static(OUTPUT_DIR));
 app.use('/logo', express.static(LOGO_DIR));
@@ -33,6 +37,7 @@ let browser = null;
 let page = null;
 let captureInterval = null;
 let isStreamReady = false;
+let isRestarting = false;
 
 const waitFor = ms => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -51,20 +56,35 @@ function getContainerLimits() {
   let memLimitPath = '/sys/fs/cgroup/memory.max';
   let cpus = os.cpus().length;
   let memory = os.totalmem();
-  try { const [quota, period] = fs.readFileSync(cpuQuotaPath,'utf8').trim().split(' '); if(quota!=='max') cpus=parseFloat((parseInt(quota)/parseInt(period)).toFixed(2)); } catch {}
-  try { const raw = fs.readFileSync(memLimitPath,'utf8').trim(); if(raw!=='max') memory=parseInt(raw); } catch {}
-  return { cpus, memoryMB: Math.round(memory/(1024*1024)) };
+
+  try {
+    const [quota, period] = fs.readFileSync(cpuQuotaPath, 'utf8').trim().split(' ');
+    if (quota !== 'max') {
+      cpus = parseFloat((parseInt(quota, 10) / parseInt(period, 10)).toFixed(2));
+    }
+  } catch {}
+
+  try {
+    const raw = fs.readFileSync(memLimitPath, 'utf8').trim();
+    if (raw !== 'max') memory = parseInt(raw, 10);
+  } catch {}
+
+  return { cpus, memoryMB: Math.round(memory / (1024 * 1024)) };
 }
 
 function createAudioInputFile() {
   const defaultMp3s = [
-    '01 Weatherscan Track 26.mp3','02 Weatherscan Track 3.mp3','03 Tropical Breeze.mp3',
-    '04 Late Nite Cafe.mp3','05 Care Free.mp3','06 Weatherscan Track 14.mp3','07 Weatherscan Track 18.mp3'
+    '01 Weatherscan Track 26.mp3',
+    '02 Weatherscan Track 3.mp3',
+    '03 Tropical Breeze.mp3',
+    '04 Late Nite Cafe.mp3',
+    '05 Care Free.mp3',
+    '06 Weatherscan Track 14.mp3',
+    '07 Weatherscan Track 18.mp3'
   ];
 
   let files = [];
   try {
-    // Read only MP3 files from AUDIO_DIR
     files = fs.readdirSync(AUDIO_DIR).filter(file => file.toLowerCase().endsWith('.mp3'));
     if (files.length === 0) {
       console.warn('No MP3 files found in music directory; using default music list');
@@ -75,8 +95,7 @@ function createAudioInputFile() {
     console.warn('Using default music list due to error');
     files = defaultMp3s;
   }
-  
-  // Shuffle if requested
+
   if (process.env.SHUFFLE_MUSIC?.toLowerCase() === 'true') {
     files = shuffleArray(files);
     console.log('Shuffled music list based on SHUFFLE_MUSIC=true');
@@ -85,10 +104,6 @@ function createAudioInputFile() {
   console.log(`Loaded ${files.length} music files`);
   const audioList = files.map(file => `file '${path.join(AUDIO_DIR, file)}'`).join('\n');
   fs.writeFileSync(path.join(__dirname, 'audio_list.txt'), audioList);
-
-
-  // Note: Update README to inform users they can add MP3 files to the 'music' folder
-  // and that the default files (listed above) are used if no MP3s are found.
 }
 
 function generateXMLTV(host) {
@@ -101,11 +116,12 @@ function generateXMLTV(host) {
 <display-name>WeatherStar 4000</display-name>
 <icon src="${baseUrl}/logo/ws4000.png" />
 </channel>`;
-  for(let i=0;i<24;i++){
-    const startTime = new Date(now.getTime()+i*3600*1000);
-    const endTime = new Date(startTime.getTime()+3600*1000);
-    const start = startTime.toISOString().replace(/[-:T]/g,'').split('.')[0]+' +0000';
-    const end = endTime.toISOString().replace(/[-:T]/g,'').split('.')[0]+' +0000';
+
+  for (let i = 0; i < 24; i++) {
+    const startTime = new Date(now.getTime() + i * 3600 * 1000);
+    const endTime = new Date(startTime.getTime() + 3600 * 1000);
+    const start = startTime.toISOString().replace(/[-:T]/g, '').split('.')[0] + ' +0000';
+    const end = endTime.toISOString().replace(/[-:T]/g, '').split('.')[0] + ' +0000';
     xml += `
 <programme start="${start}" stop="${end}" channel="WS4000">
 <title lang="en">Local Weather</title>
@@ -113,101 +129,212 @@ function generateXMLTV(host) {
 <icon src="${baseUrl}/logo/ws4000.png" />
 </programme>`;
   }
+
   xml += `</tv>`;
   return xml;
 }
 
 async function startBrowser() {
-  if(browser) await browser.close().catch(()=>{});
+  if (browser) {
+    await browser.close().catch(() => {});
+    browser = null;
+    page = null;
+  }
+
+  console.log(`Launching browser: ${PUPPETEER_EXECUTABLE_PATH}`);
+
   browser = await puppeteer.launch({
+    executablePath: PUPPETEER_EXECUTABLE_PATH,
     headless: true,
-    args:['--no-sandbox','--disable-setuid-sandbox','--disable-infobars','--ignore-certificate-errors','--window-size=1280,720'],
-    defaultViewport: null
+    defaultViewport: null,
+    args: [
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--disable-dev-shm-usage',
+      '--disable-infobars',
+      '--ignore-certificate-errors',
+      '--window-size=1280,720'
+    ]
   });
+
   page = await browser.newPage();
-  await page.goto(WS4KP_URL,{ waitUntil:'networkidle2', timeout:30000 });
+  await page.setViewport({ width: 1280, height: 720 });
+
+  await page.goto(WS4KP_URL, {
+    waitUntil: 'networkidle2',
+    timeout: 30000
+  });
+
   try {
-    const zipInput = await page.waitForSelector('input[placeholder="Zip or City, State"], input',{ timeout:5000 });
-    if(zipInput){
-      await zipInput.type(ZIP_CODE,{ delay:100 });
+    const zipInput = await page.waitForSelector(
+      'input[placeholder="Zip or City, State"], input',
+      { timeout: 5000 }
+    );
+
+    if (zipInput) {
+      await zipInput.click({ clickCount: 3 }).catch(() => {});
+      await zipInput.press('Backspace').catch(() => {});
+      await zipInput.type(ZIP_CODE, { delay: 100 });
       await waitFor(1000);
       await page.keyboard.press('ArrowDown');
       await waitFor(500);
+
       const goButton = await page.$('button[type="submit"]');
-      if(goButton) await goButton.click(); else await zipInput.press('Enter');
-      await page.waitForSelector('div.weather-display, #weather-content',{ timeout:30000 });
+      if (goButton) {
+        await goButton.click();
+      } else {
+        await zipInput.press('Enter');
+      }
+
+      await page.waitForSelector('div.weather-display, #weather-content', {
+        timeout: 30000
+      });
     }
-  } catch {}
-  await page.setViewport({ width:1280, height:720 });
+  } catch (err) {
+    console.warn(`ZIP entry step skipped or failed: ${err.message}`);
+  }
+}
+
+async function restartTranscoding() {
+  if (isRestarting) return;
+  isRestarting = true;
+
+  try {
+    console.log('Restarting transcoder...');
+    await stopTranscoding();
+    await waitFor(2000);
+    await startTranscoding();
+  } finally {
+    isRestarting = false;
+  }
 }
 
 async function startTranscoding() {
   await startBrowser();
   createAudioInputFile();
+
   ffmpegStream = new PassThrough();
+
   ffmpegProc = ffmpeg()
     .input(ffmpegStream)
     .inputFormat('image2pipe')
     .inputOptions([`-framerate ${FRAME_RATE}`])
-    .input(path.join(__dirname,'audio_list.txt'))
-    .inputOptions(['-f concat','-safe 0','-stream_loop -1'])
-    .complexFilter(['[0:v]scale=1280:720[v]','[1:a]volume=0.5[a]'])
-    .outputOptions(['-map [v]','-map [a]','-c:v libx264','-c:a aac','-b:a 128k','-preset ultrafast','-b:v 1000k','-f hls','-hls_time 2','-hls_list_size 2','-hls_flags delete_segments'])
+    .input(path.join(__dirname, 'audio_list.txt'))
+    .inputOptions(['-f concat', '-safe 0', '-stream_loop -1'])
+    .complexFilter(['[0:v]scale=1280:720[v]', '[1:a]volume=0.5[a]'])
+    .outputOptions([
+      '-map [v]',
+      '-map [a]',
+      '-c:v libx264',
+      '-c:a aac',
+      '-b:a 128k',
+      '-preset ultrafast',
+      '-b:v 1000k',
+      '-f hls',
+      '-hls_time 2',
+      '-hls_list_size 2',
+      '-hls_flags delete_segments'
+    ])
     .output(HLS_FILE)
-    .on('start',()=>{ console.log(`Started FFmpeg - Version ${VERSION}`); setTimeout(()=>isStreamReady=true,HLS_SETUP_DELAY); })
-    .on('error', async err=>{ console.error('FFmpeg error:',err); await stopTranscoding(); startTranscoding(); })
-    .on('end',()=>{ ffmpegProc=null; ffmpegStream=null; isStreamReady=false; });
+    .on('start', () => {
+      console.log(`Started FFmpeg - Version ${VERSION}`);
+      setTimeout(() => {
+        isStreamReady = true;
+      }, HLS_SETUP_DELAY);
+    })
+    .on('error', async err => {
+      console.error('FFmpeg error:', err);
+      await restartTranscoding();
+    })
+    .on('end', () => {
+      ffmpegProc = null;
+      ffmpegStream = null;
+      isStreamReady = false;
+    });
 
-  captureInterval = setInterval(async ()=>{
-    if(!ffmpegProc || !ffmpegStream || !page) return;
-    try{
-      if(page.isClosed()){ await startBrowser(); return; }
-      // Updated 16:9 capture for version 1.6
+  captureInterval = setInterval(async () => {
+    if (!ffmpegProc || !ffmpegStream || !page) return;
+
+    try {
+      if (page.isClosed()) {
+        await startBrowser();
+        return;
+      }
+
       const screenshot = await page.screenshot({
-        type:'jpeg',
-        clip:{ x:4, y:50, width:840, height:470 } // crop top, right, and bottom based on your measurements
+        type: 'jpeg',
+        clip: { x: 4, y: 50, width: 840, height: 470 }
       });
+
       ffmpegStream.write(screenshot);
-    } catch(err){
+    } catch (err) {
       console.warn('Capture error, retrying...', err.message);
       await startBrowser();
     }
-  },1000/FRAME_RATE);
+  }, 1000 / FRAME_RATE);
 
   ffmpegProc.run();
 }
 
-async function stopTranscoding(){
-  if(captureInterval) clearInterval(captureInterval);
-  captureInterval=null; isStreamReady=false;
-  if(ffmpegProc) ffmpegProc.kill('SIGINT'); ffmpegProc=null;
-  if(browser) await browser.close().catch(()=>{}); browser=null;
+async function stopTranscoding() {
+  if (captureInterval) clearInterval(captureInterval);
+  captureInterval = null;
+  isStreamReady = false;
+
+  if (ffmpegProc) {
+    ffmpegProc.kill('SIGINT');
+    ffmpegProc = null;
+  }
+
+  if (ffmpegStream) {
+    ffmpegStream.end();
+    ffmpegStream = null;
+  }
+
+  if (browser) {
+    await browser.close().catch(() => {});
+    browser = null;
+    page = null;
+  }
 }
 
-app.get('/playlist.m3u',(req,res)=>{
+app.get('/playlist.m3u', (req, res) => {
   const host = req.headers.host || `localhost:${STREAM_PORT}`;
   const baseUrl = `http://${host}`;
   const m3uContent = `#EXTM3U
 #EXTINF:-1 channel-id="weatherStar4000" tvg-id="weatherStar4000" tvg-channel-no="275" tvc-guide-placeholders="3600" tvc-guide-title="Local Weather" tvc-guide-description="Enjoy your local weather with a touch of nostalgia." tvc-guide-art="${baseUrl}/logo/ws4000.png" tvg-logo="${baseUrl}/logo/ws4000.png",WeatherStar 4000
 ${baseUrl}/stream/stream.m3u8
 `;
-  res.set('Content-Type','application/x-mpegURL'); res.send(m3uContent);
+  res.set('Content-Type', 'application/x-mpegURL');
+  res.send(m3uContent);
 });
 
-app.get('/guide.xml',(req,res)=>{
+app.get('/guide.xml', (req, res) => {
   const host = req.headers.host || `localhost:${STREAM_PORT}`;
-  res.set('Content-Type','application/xml'); res.send(generateXMLTV(host));
+  res.set('Content-Type', 'application/xml');
+  res.send(generateXMLTV(host));
 });
 
-app.get('/health',(req,res)=>{ res.status(isStreamReady?200:503).json({ready:isStreamReady}); });
+app.get('/health', (req, res) => {
+  res.status(isStreamReady ? 200 : 503).json({ ready: isStreamReady });
+});
 
 const { cpus, memoryMB } = getContainerLimits();
 console.log(`Version ${VERSION} | Running with ${cpus} CPU cores, ${memoryMB}MB RAM`);
 
-app.listen(STREAM_PORT, async ()=>{
+app.listen(STREAM_PORT, async () => {
   console.log(`Streaming server running on port ${STREAM_PORT}`);
   await startTranscoding();
 });
 
-process.on('SIGINT', async ()=>{ console.log('SIGINT received'); await stopTranscoding(); process.exit(); });
-process.on('SIGTERM', async ()=>{ console.log('SIGTERM received'); await stopTranscoding(); process.exit(); });
+process.on('SIGINT', async () => {
+  console.log('SIGINT received');
+  await stopTranscoding();
+  process.exit();
+});
+
+process.on('SIGTERM', async () => {
+  console.log('SIGTERM received');
+  await stopTranscoding();
+  process.exit();
+});

--- a/index.js
+++ b/index.js
@@ -216,7 +216,8 @@ async function startTranscoding() {
     })
     .on('error', async err => {
       console.error('FFmpeg error:', err);
-      await restartTranscoding();
+      await stopTranscoding();
+      startTranscoding();
     })
     .on('end', () => {
       ffmpegProc = null;

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ const STREAM_PORT = process.env.STREAM_PORT || '9798';
 const WS4KP_URL = `http://${WS4KP_HOST}:${WS4KP_PORT}`;
 const HLS_SETUP_DELAY = 2000;
 const FRAME_RATE = Number(process.env.FRAME_RATE || 10);
+const WS4KP_INTERNATIONAL = process.env.WS4KP_INTERNATIONAL?.toLowerCase() === 'true';
 const PUPPETEER_EXECUTABLE_PATH =
   process.env.PUPPETEER_EXECUTABLE_PATH || '/usr/bin/google-chrome-stable';
 
@@ -263,7 +264,7 @@ async function startTranscoding() {
 
       const screenshot = await page.screenshot({
         type: 'jpeg',
-        clip: { x: 4, y: 50, width: 840, height: 470 }
+        clip: { x: WS4KP_INTERNATIONAL ? 8 : 4, y: 50, width: 840, height: 470 }
       });
 
       ffmpegStream.write(screenshot);

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const WS4KP_HOST = process.env.WS4KP_HOST || 'localhost';
 const WS4KP_PORT = process.env.WS4KP_PORT || '8080';
 const STREAM_PORT = process.env.STREAM_PORT || '9798';
 const WS4KP_URL = `http://${WS4KP_HOST}:${WS4KP_PORT}`;
+const PERMALINK_URL = process.env.PERMALINK_URL || null;
 const HLS_SETUP_DELAY = 2000;
 const FRAME_RATE = process.env.FRAME_RATE || 10;
 
@@ -125,19 +126,24 @@ async function startBrowser() {
     defaultViewport: null
   });
   page = await browser.newPage();
-  await page.goto(WS4KP_URL,{ waitUntil:'networkidle2', timeout:30000 });
-  try {
-    const zipInput = await page.waitForSelector('input[placeholder="Zip or City, State"], input',{ timeout:5000 });
-    if(zipInput){
-      await zipInput.type(ZIP_CODE,{ delay:100 });
-      await waitFor(1000);
-      await page.keyboard.press('ArrowDown');
-      await waitFor(500);
-      const goButton = await page.$('button[type="submit"]');
-      if(goButton) await goButton.click(); else await zipInput.press('Enter');
-      await page.waitForSelector('div.weather-display, #weather-content',{ timeout:30000 });
-    }
-  } catch {}
+  if (PERMALINK_URL) {
+    console.log(`Using custom permalink URL: ${PERMALINK_URL}`);
+    await page.goto(PERMALINK_URL, { waitUntil: 'networkidle2', timeout: 30000 });
+  } else {
+    await page.goto(WS4KP_URL, { waitUntil: 'networkidle2', timeout: 30000 });
+    try {
+      const zipInput = await page.waitForSelector('input[placeholder="Zip or City, State"], input', { timeout: 5000 });
+      if (zipInput) {
+        await zipInput.type(ZIP_CODE, { delay: 100 });
+        await waitFor(1000);
+        await page.keyboard.press('ArrowDown');
+        await waitFor(500);
+        const goButton = await page.$('button[type="submit"]');
+        if (goButton) await goButton.click(); else await zipInput.press('Enter');
+        await page.waitForSelector('div.weather-display, #weather-content', { timeout: 30000 });
+      }
+    } catch {}
+  }
   await page.setViewport({ width:1280, height:720 });
 }
 


### PR DESCRIPTION
Summary

This PR upgrades the base image and adds optional Intel iGPU hardware-accelerated encoding via VAAPI.

### Changes

**Infrastructure**
- Upgraded base image from Ubuntu 22.04 to **Ubuntu 24.04**
- Upgraded Node.js to **v22**
- Updated audio library reference to `libasound2t64` (renamed in Ubuntu 24.04)
- Intel VAAPI driver stack (`intel-media-va-driver-non-free`, `libvpl2`, `libva2`, `libva-drm2`) now baked into the image on amd64

**New: Intel iGPU hardware encoding (`ENABLE_IGPU`)**
- When `ENABLE_IGPU=true`, FFmpeg uses `h264_vaapi` for encoding instead of `libx264`, offloading transcoding to the Intel iGPU
- Requires `--device=/dev/dri` passed to the container
- If the device is not found at startup, the container automatically falls back to CPU encoding (`libx264`) and logs a warning
- Container logs report the active transcoding mode on startup: `Transcoding mode: iGPU (h264_vaapi)` or `CPU (libx264)`
- amd64 only — no ARM equivalent for Intel VAAPI

**New: `WS4KP_INTERNATIONAL` variable**
- Adjusts the Puppeteer screenshot crop offset (`x: 8` vs `x: 4`) to account for international WS4KP display layouts

**No breaking changes** — all new variables default to their previous behavior when unset.