### PR TITLE
change to png screenshot

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const WS4KP_HOST = process.env.WS4KP_HOST || 'localhost';
 const WS4KP_PORT = process.env.WS4KP_PORT || '8080';
 const STREAM_PORT = process.env.STREAM_PORT || '9798';
 const WS4KP_URL = `http://${WS4KP_HOST}:${WS4KP_PORT}`;
+const PERMALINK_URL = process.env.PERMALINK_URL || null;
 const HLS_SETUP_DELAY = 2000;
 const FRAME_RATE = process.env.FRAME_RATE || 10;
 
@@ -177,7 +178,6 @@ async function startBrowser() {
         if (goButton) await goButton.click(); else await zipInput.press('Enter');
         // wait for weather content to update
         await page.waitForSelector('div.weather-display, #weather-content', { timeout: 30000 });
-        console.log('weather-display present');
       }
     } catch {}
 
@@ -234,7 +234,7 @@ async function startTranscoding() {
     .inputFormat('image2pipe')
     .inputOptions([`-framerate ${FRAME_RATE}`])
     .input(path.join(__dirname,'audio_list.txt'))
-    .inputOptions(['-f concat','-safe 0','-stream_loop -1'])
+    .inputOptions(['-f concat','-safe 0','-stream_loop -1','-vcodec png'])
     .complexFilter([`[0:v]scale=${VIEW_DIMENSIONS.width}:${VIEW_DIMENSIONS.height}[v]`,'[1:a]volume=0.5[a]'])
     .outputOptions(['-map [v]','-map [a]','-c:v libx264','-c:a aac','-b:a 128k','-preset ultrafast','-b:v 1000k','-f hls','-hls_time 2','-hls_list_size 2','-hls_flags delete_segments'])
     .output(HLS_FILE)
@@ -248,7 +248,7 @@ async function startTranscoding() {
       if(page.isClosed()){ await startBrowser(); return; }
       // Updated 16:9 capture for version 1.6
       const screenshot = await page.screenshot({
-        type:'jpeg',
+        type:'png',
         clip:{ x:0, y:0, ...VIEW_DIMENSIONS } // crop top, right, and bottom based on your measurements
       });
       ffmpegStream.write(screenshot);


### PR DESCRIPTION
These are old-school graphics with large areas of the same color. jpeg screenshots introduce jpeg artifacts that then need to be compressed by ffmpeg/h264 less efficiently. This feeds the full-quality png screenshot to the video stream for better compression.

PNG from the stream on the left, and JPEG from the stream on the right.
<img width="1902" height="716" alt="image" src="https://github.com/user-attachments/assets/da9dc317-746c-4ea4-b6d1-f96b85f8583e" />
