### PR TITLE
Fix: HLS segments default to a 25s keyframe interval regardless of -hls_time, breaking clients with short tune-in timeouts

### DIFF
--- a/index.js
+++ b/index.js
@@ -264,6 +264,8 @@ async function startTranscoding() {
     canWrite = true;
   });
 
+  const HLS_SEGMENT_SECONDS = 2;
+
   ffmpegProc = ffmpeg()
     .input(ffmpegStream)
     .inputFormat('image2pipe')
@@ -271,7 +273,7 @@ async function startTranscoding() {
     .input(path.join(__dirname,'audio_list.txt'))
     .inputOptions(['-f concat','-safe 0','-stream_loop -1','-vcodec png'])
     .complexFilter([`[0:v]scale=${VIEW_DIMENSIONS.width}:${VIEW_DIMENSIONS.height}[v]`,'[1:a]volume=0.5[a]'])
-    .outputOptions(['-map [v]','-map [a]','-c:v libx264','-c:a aac','-b:a 128k','-preset ultrafast','-b:v 1000k','-f hls','-hls_time 2','-hls_list_size 2','-hls_flags delete_segments'])
+    .outputOptions(['-map [v]','-map [a]','-c:v libx264','-c:a aac','-b:a 128k','-preset ultrafast',`-g ${FRAME_RATE * HLS_SEGMENT_SECONDS}`,'-b:v 1000k','-f hls',`-hls_time ${HLS_SEGMENT_SECONDS}`,'-hls_list_size 2','-hls_flags delete_segments'])
     .output(HLS_FILE)
     .on('start',()=>{ logTS(`Started FFmpeg - Version ${VERSION}`); setTimeout(()=>isStreamReady=true,HLS_SETUP_DELAY); })
     .on('error', async err=>{ logTS(`FFmpeg error: ${err.message}`); await stopTranscoding(); startTranscoding(); })


### PR DESCRIPTION
## Disclosure
I used AI to help me identify and explain this issue after spending a few weekend breaks trying to solve for this myself by tinkering around with frame rate arguments. The technology stack here is beyond my depth. However, I did review the explanation and I validated the nature of the additional parameter added to the ffmpeg run to be as described below. I also validated the output in my own setup where I was using this along with Threadfin and Plex to get a nice stream going with my morning coffee. Thank you for this project! 😄 

## Problem

The ffmpeg output pipeline (`index.js`, `startTranscoding()`) sets `-hls_time 2`,
requesting 2-second HLS segments:

```js
.outputOptions(['-map [v]','-map [a]','-c:v libx264','-c:a aac','-b:a 128k',
  '-preset ultrafast','-b:v 1000k','-f hls','-hls_time 2','-hls_list_size 2',
  '-hls_flags delete_segments'])
```

In practice, though, the served manifest shows 25-second segments:
```
#EXT-X-TARGETDURATION:25
#EXTINF:25.000000,
stream2792.ts
```

-hls_time is only a minimum — ffmpeg's HLS muxer can only cut a new
segment at a keyframe boundary. Since no -g (GOP size) is set, libx264
falls back to its default keyframe interval of 250 frames. At the default
FRAME_RATE=10, that's 250 / 10 = 25 seconds between keyframes, so every
segment ends up ~25s long no matter what -hls_time requests. This isn't a
runtime performance issue or something that drifts over time — it's static
and reproducible from the very first segment on a fresh container start.

## Impact

Any downstream consumer that needs to join the stream quickly is affected.
I ran into this feeding the channel through Threadfin into Plex's
Live TV — Plex's tuner-validation step gives up after ~20s if it can't get
a decodable frame, and with segments this long a new viewer frequently
can't get anything playable inside that window, so playback fails outright
("Recording failed. Please check your tuner or antenna."). The same
25s-to-first-keyframe cost applies to any client joining mid-stream
(other DVR/tuner proxies, HLS players hitting stream.m3u8 directly,
etc.) — Threadfin just happens to be what surfaced it, this isn't
Threadfin-specific.

It also means -hls_time 2 / -hls_list_size 2 aren't doing what they
look like they're doing for anyone reading the code — the actual segment
length is silently controlled by libx264's default GOP size instead.

## Fix

Set -g explicitly, scaled to FRAME_RATE so the keyframe interval tracks
the configured segment duration instead of silently drifting with whatever
frame rate is in use.

Deriving both -g and -hls_time from a single HLS_SEGMENT_SECONDS
constant keeps them from drifting apart again, and keeps the fix correct
at any FRAME_RATE a user configures — not just the default of 10.

## Testing

Verified on a live deployment at both FRAME_RATE=10 and FRAME_RATE=5:

- Before: #EXT-X-TARGETDURATION:25 from the first segment on a fresh
container start, at both frame rates.
- After (-g 20 at FRAME_RATE=10, -g 10 at FRAME_RATE=5): consistent
#EXT-X-TARGETDURATION:2, matching the configured -hls_time.
- Confirmed via ffprobe that a fresh client can get a decodable stream
in ~3s post-fix, versus 20s+ (frequently timing out entirely) before.